### PR TITLE
Add lockfile

### DIFF
--- a/lua/lazy-patcher/patcher.lua
+++ b/lua/lazy-patcher/patcher.lua
@@ -2,6 +2,10 @@ local log = require("lazy-patcher.logger")
 
 ---@class LazyPatcher.Main
 ---@field tmp_file string?
+---@field lockfile_inode string?
+---@field is_stashed boolean?
+---@field is_aborted boolean?
+---@field is_sync_event boolean?
 local M = {}
 
 ---@class LazyPatcher.PatchSpec
@@ -11,6 +15,74 @@ local M = {}
 ---@field patch_guard_path string
 ---@field patch_name string
 ---@field patch_path string
+
+---@param opts LazyPatcher.Options
+---@return string
+function M.lockfile(opts)
+  return vim.fs.joinpath(opts.patches_path, "lock")
+end
+
+---@param opts LazyPatcher.Options
+---@param force boolean?
+function M.unlock(opts, force)
+  local lock = M.lockfile(opts)
+  local stat, _ = vim.uv.fs_stat(lock)
+  if stat ~= nil and (force or stat.ino == M.lockfile_inode) then
+    vim.uv.fs_unlink(lock)
+  end
+  M.lockfile_inode = nil
+end
+
+---@param opts LazyPatcher.Options
+---@param force boolean?
+---@return boolean?
+function M.lock(opts, force)
+  if not force and M.lockfile_inode ~= nil then
+    return true
+  end
+
+  local lock = M.lockfile(opts)
+  while true do
+    local fd, err = vim.uv.fs_open(lock, "wx", tonumber("644", 8))
+    if fd ~= nil then
+      local stat, _ = vim.uv.fs_fstat(fd)
+      vim.uv.fs_close(fd)
+      M.lockfile_inode = stat.ino
+      return true
+    end
+
+    local time = "(unknown)"
+    local stat, _ = vim.uv.fs_stat(lock)
+    if stat ~= nil then
+      time = os.date(nil, stat.mtime.sec)
+    end
+
+    local msg = ([[
+Lazy-patcher already has a lock on.
+
+%s
+Last touched at %s
+
+How to proceed?
+    ]]):format(err, time)
+
+    local choice = 0
+    pcall(function()
+      choice = vim.fn.confirm(msg, "&Try again\n&Recreate lockfile (dangerous!)\n&Skip stashing", 0)
+
+      -- Avoid paginating log messages
+      vim.cmd.redraw()
+    end)
+
+    if choice == 2 then
+      vim.uv.fs_unlink(lock)
+    end
+
+    if choice == 3 then
+      return
+    end
+  end
+end
 
 ---@param opts LazyPatcher.Options
 ---@param plugin_name string
@@ -509,6 +581,14 @@ function M.create_group_and_cmd(opts)
     log.print_warning()
   end, "Sure want to apply all local changes to plugins? (Might be breaking)")
 
+  vim.api.nvim_create_user_command("LazyPatcherLock", function()
+    M.lock(opts, true)
+  end, {})
+
+  vim.api.nvim_create_user_command("LazyPatcherUnlock", function()
+    M.unlock(opts, true)
+  end, {})
+
   create_action_all_cmd("LazyPatcherRestoreApplyAll", function()
     log.clear()
     pcall(function()
@@ -525,13 +605,20 @@ function M.create_group_and_cmd(opts)
     group = group_id,
     pattern = { "LazySyncPre", "LazyInstallPre", "LazyUpdatePre", "LazyCheckPre" },
     callback = function(ev)
+      M.is_sync_event = M.is_sync_event or ev.match == "LazySyncPre"
+
+      if M.is_stashed or M.is_aborted then
+        return
+      end
+
+      if not M.lock(opts) then
+        M.is_aborted = true -- TODO: do we really need to track this?
+        return
+      end
+
       log.clear()
-      if not M.sync_call then
-        M.restore_all(opts)
-      end
-      if ev.match == "LazySyncPre" then
-        M.sync_call = true
-      end
+      M.is_stashed = true
+      M.restore_all(opts)
       log.print_warning()
     end,
   })
@@ -541,12 +628,21 @@ function M.create_group_and_cmd(opts)
     group = group_id,
     pattern = { "LazySync", "LazyInstall", "LazyUpdate", "LazyCheck" },
     callback = function(ev)
-      if not M.sync_call then
-        M.apply_all(opts)
-      elseif ev.match == "LazySync" then
-        M.apply_all(opts)
-        M.sync_call = false
+      if not M.is_stashed or M.is_aborted then
+        M.is_stashed = false
+        M.is_aborted = false
+        return
       end
+
+      -- Lazy does the actual sync in between other events and LazySync
+      if M.is_sync_event and ev.match ~= "LazySync" then
+        return
+      end
+
+      M.is_stashed = false
+      M.is_sync_event = false
+      M.apply_all(opts)
+      M.unlock(opts)
       log.print_warning()
     end,
   })

--- a/lua/lazy-patcher/patcher.lua
+++ b/lua/lazy-patcher/patcher.lua
@@ -45,7 +45,7 @@ local git = {
   config_excludes_file = "config get --null --default= core.excludesFile",
 }
 
-function list_tbl_flatten_strings(t)
+local function list_tbl_flatten_strings(t)
   local f = function(stack)
     ::retry::
     if #stack == 0 then
@@ -68,6 +68,43 @@ function list_tbl_flatten_strings(t)
     return v
   end
   return f, { { t, nil } }
+end
+
+---@param contents string
+---@param filename string
+---@return string?
+local function create_mv_file(contents, filename)
+  local tmp = string.format("%s.tmp%08x", filename, math.random(0xffffffff))
+  local file, err = io.open(tmp, "wb")
+  if file == nil then
+    return err
+  end
+
+  _, err = file:write(contents)
+  file:close()
+  if err ~= nil then
+    vim.uv.fs_unlink(tmp)
+    return err
+  end
+
+  _, err = vim.uv.fs_rename(tmp, filename)
+  if err ~= nil then
+    return err
+  end
+end
+
+---@param filename string
+---@return string, string?
+function read_file(filename)
+  local file, err = io.open(filename, "rb")
+  if file == nil then
+    return "", err
+  end
+
+  local contents
+  contents, err = file:read("*a")
+  file:close()
+  return contents or "", err
 end
 
 ---@param opts LazyPatcher.Options
@@ -101,12 +138,8 @@ function M.extra_excludes_file(opts, spec)
 
   local lines = ""
   if not is_optional or vim.uv.fs_access(excludes_path, "r") then
-    local file, err = io.open(excludes_path, "rb")
-    if err == nil then
-      assert(file ~= nil)
-      lines, err = file:read("a")
-      file:close()
-    end
+    local err
+    lines, err = read_file(excludes_path)
     if err ~= nil then
       local s = log.scope("Checking `%s`", spec.plugin_name)
       s:set_level(vim.log.levels.WARN)
@@ -125,19 +158,15 @@ function M.extra_excludes_file(opts, spec)
     })
   end
 
-  local file, err = io.open(M.tmp_file, "wb")
-  if err ~= nil then
-    log.scope("Error writing temp file `%s` :%s", M.tmp_file, err)
-    return
-  end
-  assert(file ~= nil)
-
   for line in list_tbl_flatten_strings(opts.extra_gitignore) do
     lines = lines .. "\n" .. line
   end
 
-  file:write(lines)
-  file:close()
+  local err = create_mv_file(lines, M.tmp_file)
+  if err ~= nil then
+    log.scope("Error writing temp file `%s`: %s", M.tmp_file, err)
+    return
+  end
 
   return M.tmp_file
 end
@@ -184,14 +213,12 @@ function M.restore(opts, spec)
   end
 
   -- Save stash's diff as a new patch guard
-  local file, err = io.open(spec.patch_guard_path, "w")
-  if file == nil then
+  local err = create_mv_file(resp.output, spec.patch_guard_path)
+  if err ~= nil then
     s:log("Failed to save patch '%s': %s", spec.patch_guard_path, err)
     M.git_execute(spec.plugin_path, vim.split(git.stash_pop, " "))
     return
   end
-  file:write(resp.output)
-  file:close()
 
   s:set_ok()
   return true
@@ -213,13 +240,11 @@ function M.apply(opts, spec)
   end
 
   -- Retrieve the patch guard
-  local file, err = io.open(spec.patch_guard_path, "r")
-  if file == nil then
+  local patch, err = read_file(spec.patch_guard_path)
+  if err ~= nil then
     s:log("Failed to open a guard patch at `%s`: %s", spec.patch_guard_path, err)
     return
   end
-  local patch = file:read("*a")
-  file:close()
 
   -- Compare the stash's diff with the patch guard
   if resp.output ~= patch then


### PR DESCRIPTION
Add a lock file held during the lazy operations. If lock can't be acquired, the user is prompted whether to retry, recreate lock, or skip stashing. It would probably also make sense to cancel whatever the lazy is doing, but I haven't found a knob for this.

And also add handling for fs write errors, e.g. no-space-left.

Fixes #2.